### PR TITLE
将搜索词分为搜索词及文件名两部分,便于更精确搜索以及实现保存下载保存文件名的自定义

### DIFF
--- a/xiaomusic/static/app.js
+++ b/xiaomusic/static/app.js
@@ -39,8 +39,9 @@ $(function(){
   }
 
   $("#play").on("click", () => {
-    name = $("#music-name").val();
-    let cmd = "播放歌曲"+name;
+    var search_key = $("#music-name").val();
+    var filename=$("#music-filename").val();
+    let cmd = "播放歌曲"+search_key+"|"+filename;
     sendcmd(cmd);
   });
 

--- a/xiaomusic/static/index.html
+++ b/xiaomusic/static/index.html
@@ -44,7 +44,8 @@
     </div>
     <hr>
     <div>
-      <input id="music-name" type="text" placeholder="请输入歌曲名称"></input>
+      <input id="music-name" type="text" placeholder="请输入搜索关键词(如:MV高清版 周杰伦 七里香)"></input>
+      <input id="music-filename" type="text" placeholder="请输入保存为的文件名称(如:周杰伦-七里香)"></input>
       <button id="play">播放</button>
     </div>
 </body>


### PR DESCRIPTION
b站搜索时候,默认搜索到的歌曲可能是别人翻唱的视频,原打算看看能否用yt-dlp或其他工具实现搜索结果预览及选择,在选择后再下载.
目前使用方式:在B站搜索到结果后,根据标题,在面板中填入较为精确的搜索词和文件名,然后再搜索下载,并保存为指定的文件名.例如,搜索"七里香"可能下载到的不是周杰伦的原版,需要根据b站的搜索词排名规则填写才能找到正确版本,可能是"博主abc MV版高清 周杰伦 七里香"这样的搜索词才能定位到想要的,但是下载后又不想把文件名称保存这么长,所以又提供了文件名的input;
