### PR TITLE
可配置xiaomuisc激活指令,其他指令需要激活后才能使用

### DIFF
--- a/xiaomusic/config.py
+++ b/xiaomusic/config.py
@@ -89,6 +89,7 @@ class Config:
         "XIAOMUSIC_SEARCH", "ytsearch:"
     )  # "bilisearch:" or "ytsearch:"
     ffmpeg_location: str = os.getenv("XIAOMUSIC_FFMPEG_LOCATION", "./ffmpeg/bin")
+    active_cmd: str = os.getenv("XIAOMUSIC_ACTIVE_CMD", "")
 
     def __post_init__(self) -> None:
         if self.proxy:


### PR DESCRIPTION
1. 语音控制的情况下，部分指令可能干扰小爱原有功能，比如正在播放小爱的歌单，语音控制下一首，会触发到xiaomusic，导致不能正常播歌单的下一首

调整方式：
增加XIAOMUSIC_ACTIVE_CMD的环境变量配置，比如配置成'play,random_play'，那么在非播放状态下，只有这两个指令可以触发，触发后，xiaomusic进入playing状态，其他指令则可以正常触发。

2. https://github.com/hanxi/xiaomusic/issues/36#issue-2258831068 
调整方式：
语音指令解析为空的情况下，如果当前是playing状态，那么执行stop

以上调整不影响控制面板操作的情况