### PR TITLE
修复windows下路径分隔符被视为转移符导致音箱无法播放音乐的问题

### DIFF
--- a/xiaomusic/xiaomusic.py
+++ b/xiaomusic/xiaomusic.py
@@ -466,7 +466,7 @@ class XiaoMusic:
             self.log.debug("get_music_url web music. name:%s, url:%s", name, url)
             return url
 
-        filename = self.get_filename(name)
+        filename = self.get_filename(name).replace('\\','/')
         self.log.debug(
             "get_music_url local music. name:%s, filename:%s", name, filename
         )


### PR DESCRIPTION
由于Windows路径中使用反斜杠（\）作为目录分隔符，而在URL编码中反斜杠被视为特殊字符所导致windows下拼接得到的url不符合预期 示例
filename：music\outside.mp3
预期：
url: /music/outside.mp3
实际：
url：/music%5Coutside.mp3


需要一个办法来处理windows下的\\路径分隔符,我给出了一种简单的解法,作者可以考虑看看怎么处理会完全一点