### PR TITLE
修复m4a格式获取时长，指定读取文件的编码格式

### DIFF
--- a/xiaomusic/cli.py
+++ b/xiaomusic/cli.py
@@ -136,7 +136,7 @@ def main():
 
     try:
         filename = config.getsettingfile()
-        with open(filename) as f:
+        with open(filename,encoding="utf-8") as f:
             data = json.loads(f.read())
             config.update_config(data)
     except Exception as e:

--- a/xiaomusic/utils.py
+++ b/xiaomusic/utils.py
@@ -191,10 +191,7 @@ def is_mp3(url):
 
 
 def is_m4a(url):
-    mt = mimetypes.guess_type(url)
-    if mt and mt[0] == "audio/m4a":
-        return True
-    return False
+    return url.endswith(".m4a")
 
 
 async def _get_web_music_duration(session, url, start=0, end=500):

--- a/xiaomusic/xiaomusic.py
+++ b/xiaomusic/xiaomusic.py
@@ -224,7 +224,7 @@ class XiaoMusic:
             self.log.error(f"{self.mi_token_home} file not exist")
             return None
 
-        with open(self.mi_token_home) as f:
+        with open(self.mi_token_home,encoding="utf-8") as f:
             user_data = json.loads(f.read())
         user_id = user_data.get("userId")
         service_token = user_data.get("micoapi")[1]
@@ -752,7 +752,7 @@ class XiaoMusic:
     def try_init_setting(self):
         try:
             filename = self.config.getsettingfile()
-            with open(filename) as f:
+            with open(filename,encoding="utf-8") as f:
                 data = json.loads(f.read())
                 self.update_config_from_setting(data)
         except FileNotFoundError:


### PR DESCRIPTION
1. Windows在pycharm下运行时会因为读取配置文件的编码问题无法正确加载配置文件
解决：手动指定编码为utf-8
2. m4a格式的文件通过mutagen无法获取到播放时长导致一直单曲循环
解决：改为通过ffprobe获取音频时长。
docker下minetypes获取不到m4a的类型，所以改用文件名判断是否为m4a

不是很擅长python，如有问题请见谅。