### PR TITLE
搜索的歌曲存成列表供前端显示；实现额外索引

### DIFF
--- a/xiaomusic/utils.py
+++ b/xiaomusic/utils.py
@@ -596,3 +596,10 @@ def get_m4a_metadata(file_path):
         metadata["picture"] = base64.b64encode(cover).decode("utf-8")
 
     return metadata
+
+
+def list2str(li, verbose=False):
+    if len(li) > 5 and not verbose:
+        return f"{li[:2]} ... {li[-2:]} with len: {len(li)}"
+    else:
+        return f"{li}"

--- a/xiaomusic/utils.py
+++ b/xiaomusic/utils.py
@@ -119,7 +119,7 @@ def find_best_match(user_input, collection, cutoff=0.6, n=1):
     if len(matches) < n:
         # 如果没有准确关键词匹配，开始模糊匹配
         matches += difflib.get_close_matches(
-            user_input, lower_collection.keys(), n=n, cutoff=cutoff
+            user_input, remains, n=n, cutoff=cutoff
         )
     return [lower_collection[match] for match in matches[:n]]
 

--- a/xiaomusic/utils.py
+++ b/xiaomusic/utils.py
@@ -85,13 +85,9 @@ def validate_proxy(proxy_str: str) -> bool:
 
 
 # 模糊搜索
-def fuzzyfinder(user_input, collection):
-    lower_collection = {item.lower(): item for item in collection}
-    user_input = user_input.lower()
-    matches = difflib.get_close_matches(
-        user_input, lower_collection.keys(), n=10, cutoff=0.1
-    )
-    return [lower_collection[match] for match in matches]
+def fuzzyfinder(user_input, collection, extra_search_index=None):
+    return find_best_match(user_input, collection, cutoff=0.1, n=10,
+                           extra_search_index=extra_search_index)
 
 
 # 关键词检测
@@ -112,18 +108,31 @@ def keyword_detection(user_input, str_list, n):
     return random.sample(matched, n), remains
 
 
-def find_best_match(user_input, collection, cutoff=0.6, n=1):
-    lower_collection = {item.lower(): item for item in collection}
-    user_input = user_input.lower()
-    matches, remains = keyword_detection(user_input, lower_collection.keys(), n=n)
+def real_search(prompt, candidates, cutoff, n):
+    matches, remains = keyword_detection(prompt, candidates, n=n)
     if len(matches) < n:
         # 如果没有准确关键词匹配，开始模糊匹配
         matches += difflib.get_close_matches(
-            user_input, remains, n=n, cutoff=cutoff
+            prompt, remains, n=n, cutoff=cutoff
         )
-    return [lower_collection[match] for match in matches[:n]]
+    return matches
 
 
+def find_best_match(user_input, collection, cutoff=0.6, n=1, extra_search_index=None):
+    lower_collection = {item.lower(): item for item in collection}
+    user_input = user_input.lower()
+    matches = real_search(user_input, lower_collection.keys(), cutoff, n)
+    cur_matched_collection = [lower_collection[match] for match in matches]
+    if len(matches) >= n or extra_search_index is None:
+        return cur_matched_collection[:n]
+
+    # 如果数量不满足，继续搜索
+    lower_extra_search_index = {k.lower():v for k, v in extra_search_index.items()}
+    matches = real_search(user_input, lower_extra_search_index.keys(), cutoff, n)
+    cur_matched_collection += [lower_extra_search_index[match] for match in matches]
+    return cur_matched_collection[:n]
+    
+    
 # 歌曲排序
 def custom_sort_key(s):
     # 使用正则表达式分别提取字符串的数字前缀和数字后缀

--- a/xiaomusic/xiaomusic.py
+++ b/xiaomusic/xiaomusic.py
@@ -879,8 +879,14 @@ class XiaoMusic:
         return search_list
 
     # 获取播放列表
-    def get_music_list(self):
-        return self.music_list
+    def get_music_list(self, convert_to_basename=True):
+        if convert_to_basename:
+            basename_list = {}
+            for k, v in self.music_list.items():
+                basename_list[k] = [os.path.basename(vi) for vi in v]
+            return basename_list
+        else:
+            return self.music_list
 
     # 获取当前的播放列表
     def get_cur_play_list(self, did):

--- a/xiaomusic/xiaomusic.py
+++ b/xiaomusic/xiaomusic.py
@@ -466,8 +466,8 @@ class XiaoMusic:
                 all_music_by_dir[dir_name] = {}
             for file in files:
                 # 歌曲名字相同会覆盖
-                # filename = os.path.basename(file)
-                (name, _) = os.path.splitext(file)
+                filename = os.path.basename(file)
+                (name, _) = os.path.splitext(filename)
                 self.all_music[name] = file
                 self.all_music_tags[name] = get_audio_metadata(file)
                 all_music_by_dir[dir_name][name] = True
@@ -879,14 +879,8 @@ class XiaoMusic:
         return search_list
 
     # 获取播放列表
-    def get_music_list(self, convert_to_basename=True):
-        if convert_to_basename:
-            basename_list = {}
-            for k, v in self.music_list.items():
-                basename_list[k] = [os.path.basename(vi) for vi in v]
-            return basename_list
-        else:
-            return self.music_list
+    def get_music_list(self):
+        return self.music_list
 
     # 获取当前的播放列表
     def get_cur_play_list(self, did):

--- a/xiaomusic/xiaomusic.py
+++ b/xiaomusic/xiaomusic.py
@@ -50,14 +50,8 @@ from xiaomusic.utils import (
     parse_str_to_dict,
     remove_id3_tags,
     traverse_music_directory,
+    list2str,
 )
-
-
-def list2str(li, verbose=False):
-    if len(li) > 5 and not verbose:
-        return f"{li[:2]} ... {li[-2:]} with len: {len(li)}"
-    else:
-        return f"{li}"
 
 
 class XiaoMusic:


### PR DESCRIPTION
根据 [c72a619](https://github.com/hanxi/xiaomusic/commit/c72a619df0063a5a87994cee6ff40ff6ee8a000e)，将搜索歌曲得到的播放列表存下来以在前端显示，改名为“临时搜索列表”。

对于 #186 
1. 文件名包括文件夹路径：取完整路径作为music name（由于 name 变长了，原来模糊匹配的相似度可能会降低）
2. 播放列表排序：后端改成了有序字典并调整了 music_list 的构建顺序（前端好像不能区分列表种类，我也不太会这种特殊规则的前端排序实现）