### PR TITLE
增加 tag 缓存

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ docker build -t xiaomusic .
 - XIAOMUSIC_HTTPAUTH_USERNAME 配置 web 控制台用户，对应后台的 【web控制台账户】
 - XIAOMUSIC_HTTPAUTH_PASSWORD 配置 web 控制台密码，对应后台的 【web控制台密码】
 - XIAOMUSIC_CONF_PATH 用来存放配置文件的目录，对应后台的 【配置文件目录】，记得把目录映射到主机，默认为 `/app/config` ，具体见 <https://github.com/hanxi/xiaomusic/issues/74>
+- XIAOMUSIC_TAG_CACHE_DIR 用来音乐 tag 缓存，默认为空（不缓存）
 - XIAOMUSIC_DISABLE_DOWNLOAD 设为 true 时关闭下载功能，对应后台的 【关闭下载功能】，见 <https://github.com/hanxi/xiaomusic/issues/82>
 - XIAOMUSIC_USE_MUSIC_API 设为 true 时使用 player_play_music 接口播放音乐，对应后台的 【触屏版兼容模式】，用于兼容不能播放的型号，如果发现需要设置这个选项的时候请告知我加一下设备型号，方便以后不用设置。 见 <https://github.com/hanxi/xiaomusic/issues/30>
 - XIAOMUSIC_KEYWORDS_PLAY 用来播放歌曲的口令前缀，对应后台的 【播放歌曲口令】，默认是 "播放歌曲,放歌曲" ，可以用英文逗号分割配置多个

--- a/config-example.json
+++ b/config-example.json
@@ -7,6 +7,7 @@
   "music_path": "music",
   "download_path": "",
   "conf_path": null,
+  "tag_cache_dir": null,
   "hostname": "192.168.2.5",
   "port": 8090,
   "public_port": 0,

--- a/xiaomusic/config.py
+++ b/xiaomusic/config.py
@@ -84,6 +84,7 @@ class Config:
     )  # 只能是music目录下的子目录
     download_path: str = os.getenv("XIAOMUSIC_DOWNLOAD_PATH", "music/download")
     conf_path: str = os.getenv("XIAOMUSIC_CONF_PATH", "conf")
+    tag_cache_dir: str = os.getenv("XIAOMUSIC_TAG_CACHE_DIR", None)
     hostname: str = os.getenv("XIAOMUSIC_HOSTNAME", "192.168.2.5")
     port: int = int(os.getenv("XIAOMUSIC_PORT", "8090"))  # 监听端口
     public_port: int = int(os.getenv("XIAOMUSIC_PUBLIC_PORT", 0))  # 歌曲访问端口
@@ -245,4 +246,14 @@ class Config:
         if not os.path.exists(self.conf_path):
             os.makedirs(self.conf_path)
         filename = os.path.join(self.conf_path, "setting.json")
+        return filename
+
+    @property
+    def tag_cache_path(self):
+        if self.tag_cache_dir is None:
+            return None
+        
+        if not os.path.exists(self.tag_cache_dir):
+            os.makedirs(self.tag_cache_dir)
+        filename = os.path.join(self.tag_cache_dir, "tag_cache.json")
         return filename


### PR DESCRIPTION
关联 issue：#190

config 增加了 `tag_cache_dir`，默认为 null，为 cache 路径名
如果不为 null 会自动创建文件夹，把 cache 存在 `${tag_cache_dir}/tag_cache.json`；如果为 null 则不使用 cache

breaking change：
有些 tag value 的数据类型 json 不支持，现在强制转成了 string

待实现：
前端调用 `refresh_music_tag` 来强制刷新 tag cache（拜托作者实现了）