### PR TITLE
hotfix: multi-stage search may result in duplicates

### DIFF
--- a/xiaomusic/utils.py
+++ b/xiaomusic/utils.py
@@ -138,6 +138,7 @@ def find_best_match(user_input, collection, cutoff=0.6, n=1, extra_search_index=
     # 如果数量不满足，继续搜索
     lower_extra_search_index = {
         traditional_to_simple(k.lower()): v for k, v in extra_search_index.items()
+        if v not in cur_matched_collection
     }
     matches = real_search(user_input, lower_extra_search_index.keys(), cutoff, n)
     cur_matched_collection += [lower_extra_search_index[match] for match in matches]


### PR DESCRIPTION
搜索中已经匹配的项目应该在后续搜索中排出，避免出现重复结果。