### PR TITLE
Fix code scanning alert no. 33: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/xiaomusic/xiaomusic.py
+++ b/xiaomusic/xiaomusic.py
@@ -114,7 +114,7 @@ class XiaoMusic:
 
         url_parts = urllib.parse.urlparse(url)
         file_path = urllib.parse.unquote(url_parts.path)
-        correct_code = hashlib.md5(
+        correct_code = hashlib.sha256(
             (
                 file_path
                 + self.config.httpauth_username


### PR DESCRIPTION
Fixes [https://github.com/hanxi/xiaomusic/security/code-scanning/33](https://github.com/hanxi/xiaomusic/security/code-scanning/33)

To fix the problem, we need to replace the MD5 hashing algorithm with a stronger and more secure cryptographic hash function. In this case, SHA-256 is a suitable choice as it is widely used and considered secure for general cryptographic purposes.

- Replace the `hashlib.md5` function with `hashlib.sha256`.
- Ensure that the rest of the code remains unchanged to maintain existing functionality.
- Update the import statements if necessary to include any new dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
