### PR TITLE
Fix code scanning alert no. 32: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/xiaomusic/httpserver.py
+++ b/xiaomusic/httpserver.py
@@ -399,7 +399,7 @@ def access_key_verification(file_path, key, code):
     if code is not None:
         current_code_bytes = code.encode("utf8")
         correct_code_bytes = (
-            hashlib.md5(
+            hashlib.sha256(
                 (
                     file_path + config.httpauth_username + config.httpauth_password
                 ).encode("utf-8")


### PR DESCRIPTION
Fixes [https://github.com/hanxi/xiaomusic/security/code-scanning/32](https://github.com/hanxi/xiaomusic/security/code-scanning/32)

To fix the problem, we should replace the MD5 hashing algorithm with a stronger and more secure algorithm. For general cryptographic purposes, SHA-256 is a good choice. We will use the `hashlib.sha256` function to replace the `hashlib.md5` function.

- Replace the `hashlib.md5` call with `hashlib.sha256`.
- Ensure that the rest of the code remains unchanged to maintain existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
