### PR TITLE
request.url.path 无法正确解析路径中特殊字符

### DIFF
--- a/xiaomusic/httpserver.py
+++ b/xiaomusic/httpserver.py
@@ -419,7 +419,7 @@ range_pattern = re.compile(r"bytes=(\d+)-(\d*)")
 
 @app.get("/music/{file_path:path}")
 async def music_file(request: Request, file_path: str, key: str = "", code: str = ""):
-    if not access_key_verification(request.url.path, key, code):
+    if not access_key_verification(f"/music/{file_path}", key, code):
         raise HTTPException(status_code=404, detail="File not found")
 
     absolute_path = os.path.abspath(config.music_path)
@@ -469,7 +469,7 @@ async def music_options():
 
 @app.get("/picture/{file_path:path}")
 async def get_picture(request: Request, file_path: str, key: str = "", code: str = ""):
-    if not access_key_verification(request.url.path, key, code):
+    if not access_key_verification(f"/picture/{file_path}", key, code):
         raise HTTPException(status_code=404, detail="File not found")
 
     absolute_path = os.path.abspath(config.picture_cache_path)


### PR DESCRIPTION
路径中有 “#” 就会被切断。改成按照规则拼接了。