### PR TITLE
bug: 可以精确匹配结果时不采用模糊搜索策略

### DIFF
--- a/xiaomusic/xiaomusic.py
+++ b/xiaomusic/xiaomusic.py
@@ -785,8 +785,8 @@ class XiaoMusic:
             extra_search_index=self._extra_index_search,
         )
         if real_names:
-            if n > 1:
-                # 扩大范围再找，最后保留随机 n 个
+            if n > 1 and name not in real_names:
+                # 模糊匹配模式，扩大范围再找，最后保留随机 n 个
                 real_names = find_best_match(
                     name,
                     all_music_list,
@@ -796,6 +796,9 @@ class XiaoMusic:
                 )
                 random.shuffle(real_names)
                 real_names = real_names[:n]
+            elif name in real_names:
+                # 可以精确匹配，限制只返回一个（保证网页端播放可用）
+                real_names = [name]
             self.log.info(f"根据【{name}】找到歌曲【{real_names}】")
             return real_names
         self.log.info(f"没找到歌曲【{name}】")


### PR DESCRIPTION
模糊匹配范围太大会导致默认 UI 的播放歌曲不可用（文件名相似时，无法精确选择某一首歌）

限制如果存在精确匹配，就只返回一个结果。