### PR TITLE
fix: 修复中文数字转换函数对'十、十一'等数字的处理

### DIFF
--- a/xiaomusic/utils.py
+++ b/xiaomusic/utils.py
@@ -526,6 +526,13 @@ def chinese_to_number(chinese):
     result = 0
     unit = 1
     num = 0
+    # 处理特殊情况：以"十"开头时，在前面加"一"
+    if chinese.startswith('十'):
+        chinese = '一' + chinese
+    
+    # 如果只有一个字符且是单位，直接返回其值
+    if len(chinese) == 1 and chinese_to_arabic[chinese] >= 10:
+        return chinese_to_arabic[chinese]
     for char in reversed(chinese):
         if char in chinese_to_arabic:
             val = chinese_to_arabic[char]
@@ -536,8 +543,8 @@ def chinese_to_number(chinese):
                     unit *= val
             else:
                 num += val * unit
-        result += num
-        num = 0
+    result += num
+  
     return result
 
 


### PR DESCRIPTION
## 问题描述
当前的 `chinese_to_number` 函数在处理某些中文数字（如"十、十一"）时存在问题。

## 修改内容
- 添加了对以"十"开头的数字的特殊处理
- 优化了数字转换逻辑

## 测试用例
- "十" => 10
- "十一" => 11
- "二十" => 20
- "二十一" => 21

## 测试结果
所有测试用例均通过。