### PR TITLE
修复tailwind主题样式问题

### DIFF
--- a/xiaomusic/static/tailwind/main.css
+++ b/xiaomusic/static/tailwind/main.css
@@ -131,3 +131,8 @@
 .text-error .icon-sm {
   fill: currentColor;
 }
+
+/* 修复手机端播放列表 歌曲名称超长溢出问题 */
+.song-list .song-item .min-w-0 {
+  width: 1px;
+}


### PR DESCRIPTION
修复 tailwind主题 手机端播放列表 歌曲名称超长溢出问题。
因为不是很清楚具体主题样式实现的原理，直接在main.css中添加了修复代码，如果不合适请回复一下，谢谢。

### 图片
修复前存在的问题：
<img width="421" alt="截屏2025-02-05 上午10 36 03" src="https://github.com/user-attachments/assets/6c0bc424-f925-422b-90b5-a3186cb46c1d" />
修复后的效果：
<img width="407" alt="截屏2025-02-05 上午10 36 43" src="https://github.com/user-attachments/assets/3342755f-44b3-4070-809a-cf4746beeba4" />
