### PR TITLE
fix: 未开启模糊匹配播放错误问题

### DIFF
--- a/xiaomusic/xiaomusic.py
+++ b/xiaomusic/xiaomusic.py
@@ -923,7 +923,7 @@ class XiaoMusic:
     def find_real_music_name(self, name, n=100):
         if not self.config.enable_fuzzy_match:
             self.log.debug("没开启模糊匹配")
-            return name
+            return []
 
         all_music_list = list(self.all_music.keys())
         real_names = find_best_match(


### PR DESCRIPTION
现象为未开启模糊匹配提示播放错误，看日志是无法找到对应的歌曲。定位到这里的返回值应该是一个数组，故修改