### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -10,6 +10,9 @@ on:
       - '.github/workflows/build-base-image.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hanxi/xiaomusic/security/code-scanning/39](https://github.com/hanxi/xiaomusic/security/code-scanning/39)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily interacts with Docker Hub and does not modify repository contents, the permissions can be set to `contents: read`. This ensures that the `GITHUB_TOKEN` has minimal access while allowing the workflow to execute successfully.

The `permissions` block should be added at the root level of the workflow file, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
