### PR TITLE
Potential fix for code scanning alert no. 47: Incomplete URL substring sanitization

### DIFF
--- a/xiaomusic/utils.py
+++ b/xiaomusic/utils.py
@@ -948,7 +948,7 @@ async def check_bili_fav_list(url):
     path = parsed_url.path
     # 提取查询参数
     query_params = parse_qs(parsed_url.query)
-    if "space.bilibili.com" in url:
+    if parsed_url.hostname == "space.bilibili.com":
         if "/favlist" in path:
             lid = query_params.get("fid", [None])[0]
             type = query_params.get("ctype", [None])[0]


### PR DESCRIPTION
Potential fix for [https://github.com/hanxi/xiaomusic/security/code-scanning/47](https://github.com/hanxi/xiaomusic/security/code-scanning/47)

To fix the issue, the code should parse the URL using `urlparse` and check the `hostname` field instead of performing a substring check. This ensures that the check is performed on the actual host of the URL, avoiding false positives caused by substrings appearing elsewhere in the URL.

**Steps to fix:**
1. Replace the substring check `"space.bilibili.com" in url` with a check on the parsed hostname using `urlparse(url).hostname`.
2. Ensure that the hostname matches `space.bilibili.com` exactly or ends with `.space.bilibili.com` to allow for subdomains if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
