### PR TITLE
Potential fix for code scanning alert no. 71: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,5 +1,8 @@
 name: Update Docker Hub Description
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/hanxi/xiaomusic/security/code-scanning/71](https://github.com/hanxi/xiaomusic/security/code-scanning/71)

In general, the fix is to explicitly declare a `permissions` block to limit the `GITHUB_TOKEN` to the minimum required scope. Since this workflow only checks out the repository and uses Docker Hub credentials (username/password) to update Docker Hub, it only needs read access to repository contents.

The best fix with minimal behavioural change is to add `permissions: contents: read` at the workflow root level so it applies to all jobs (there is only one job). This satisfies CodeQL’s recommendation and follows least privilege. Concretely, in `.github/workflows/dockerhub-description.yml`, insert a `permissions` block after the `name:` line (or before `on:`) so that the job no longer inherits potentially broad default permissions. No imports or additional methods are required because this is a GitHub Actions YAML file, and `actions/checkout@v4` works with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
