### PR TITLE
fix: 点击 本地端口-自动填功能 报错

### DIFF
--- a/xiaomusic/static/default/setting.js
+++ b/xiaomusic/static/default/setting.js
@@ -256,7 +256,7 @@ $(function () {
   });
 
   $("#auto-port").on("click", () => {
-    const port = window.location.port;
+    let port = window.location.port;
     if (port == 0) {
       const protocol = window.location.protocol;
       if (protocol == "https:") {


### PR DESCRIPTION
默认主题，点击本地端口-自动填功能没有反应，查看控制台信息发现报错，报错原因是：const定义的是常量，不能重新赋值
> https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Statements/const

<img width="1917" height="881" alt="image" src="https://github.com/user-attachments/assets/893f1512-7afe-4780-8964-2428cd76e599" />
<img width="736" height="436" alt="image" src="https://github.com/user-attachments/assets/e986563f-9693-474f-9b32-e8db118fe46e" />
