### PR TITLE
feat: add /getplayerstatus API to get full player status

### DIFF
--- a/xiaomusic/api/routers/device.py
+++ b/xiaomusic/api/routers/device.py
@@ -32,6 +32,23 @@ async def getvolume(did: str = ""):
     return {"volume": volume}
 
 
+@router.get("/getplayerstatus")
+async def getplayerstatus(did: str = ""):
+    """获取完整播放状态
+
+    返回小米音箱的完整播放状态，包括：
+    - status: 播放状态 (0=停止, 1=播放)
+    - volume: 音量
+    - play_song_detail: 播放详情
+        - position: 当前播放位置（毫秒）
+        - duration: 总时长（毫秒）
+    """
+    if not xiaomusic.did_exist(did):
+        return {"status": 0, "volume": 0}
+
+    return await xiaomusic.get_player_status(did=did)
+
+
 @router.post("/setvolume")
 async def setvolume(data: DidVolume):
     """设置音量"""

--- a/xiaomusic/device_player.py
+++ b/xiaomusic/device_player.py
@@ -827,6 +827,19 @@ class XiaoMusicDevice:
         self.log.info("get_volume. volume:%d", volume)
         return volume
 
+    async def get_player_status(self):
+        """获取完整播放状态"""
+        try:
+            playing_info = await self.auth_manager.mina_service.player_get_status(
+                self.device_id
+            )
+            self.log.info(f"get_player_status. playing_info:{playing_info}")
+            info = json.loads(playing_info.get("data", {}).get("info", "{}"))
+            return info
+        except Exception as e:
+            self.log.warning(f"Execption {e}")
+        return {"volume": 0, "status": 0}
+
     async def set_play_type(self, play_type, dotts=True):
         """设置播放类型"""
         self.device.play_type = play_type

--- a/xiaomusic/xiaomusic.py
+++ b/xiaomusic/xiaomusic.py
@@ -556,6 +556,10 @@ class XiaoMusic:
     async def get_volume(self, did="", **kwargs):
         return await self.device_manager.devices[did].get_volume()
 
+    # 获取完整播放状态
+    async def get_player_status(self, did="", **kwargs):
+        return await self.device_manager.devices[did].get_player_status()
+
     # 设置音量
     async def set_volume(self, did="", arg1=0, **kwargs):
         if did not in self.device_manager.devices:


### PR DESCRIPTION
## 动机

当前 `/getvolume` 接口内部调用了 `player_get_status` 获取完整播放状态，但只返回了 `volume` 字段。

对于使用 `/api/device/pushUrl` 直接推送音乐链接到音箱的场景，需要从音箱获取真实的播放进度，而不是 xiaomusic 内部维护的数据。

## 改动

新增 `/getplayerstatus` 接口，返回小米音箱的完整播放状态：

```json
{
  "status": 1,
  "volume": 9,
  "play_song_detail": {
    "position": 229459,
    "duration": 263000
  }
}
```

## 改动文件

- `xiaomusic/api/routers/device.py` - 新增 `/getplayerstatus` 路由
- `xiaomusic/xiaomusic.py` - 新增 `get_player_status` 方法
- `xiaomusic/device_player.py` - 新增 `get_player_status` 方法

## 使用示例

```bash
curl "http://localhost:8090/getplayerstatus?did=703835710"
```