### PR TITLE
feat: add dirname parameter to /downloadonemusic API

### DIFF
--- a/xiaomusic/api/models.py
+++ b/xiaomusic/api/models.py
@@ -56,6 +56,7 @@ class DownloadPlayList(BaseModel):
 class DownloadOneMusic(BaseModel):
     name: str = ""
     url: str
+    dirname: str = ""
 
 
 class PlayListObj(BaseModel):

--- a/xiaomusic/api/routers/file.py
+++ b/xiaomusic/api/routers/file.py
@@ -167,15 +167,28 @@ async def downloadplaylist(data: DownloadPlayList, Verifcation=Depends(verificat
 
 @router.post("/downloadonemusic")
 async def downloadonemusic(data: DownloadOneMusic, Verifcation=Depends(verification)):
-    """下载单首歌曲"""
+    """下载单首歌曲
+
+    Args:
+        data.name: 文件名（可选）
+        data.url: 下载链接（必填）
+        data.dirname: 子目录名（可选），相对于下载目录
+    """
     try:
-        download_proc = await download_one_music(config, data.url, data.name)
+        download_proc = await download_one_music(
+            config, data.url, data.name, data.dirname
+        )
+
+        # 计算实际下载路径
+        download_path = config.download_path
+        if data.dirname:
+            download_path = os.path.join(config.download_path, data.dirname)
 
         async def check_download_proc():
             # 等待子进程完成
             exit_code = await download_proc.wait()
             log.info(f"Download completed with exit code {exit_code}")
-            chmoddir(config.download_path)
+            chmoddir(download_path)
 
         asyncio.create_task(check_download_proc())
         return {"ret": "OK"}

--- a/xiaomusic/utils/network_utils.py
+++ b/xiaomusic/utils/network_utils.py
@@ -191,7 +191,7 @@ async def download_playlist(config, url: str, dirname: str):
     return download_proc
 
 
-async def download_one_music(config, url: str, name: str = ""):
+async def download_one_music(config, url: str, name: str = "", dirname: str = ""):
     """
     下载单首歌曲
 
@@ -199,10 +199,17 @@ async def download_one_music(config, url: str, name: str = ""):
         config: 配置对象
         url: 歌曲 URL
         name: 文件名（可选）
+        dirname: 子目录名（可选），相对于 download_path
 
     Returns:
         下载进程对象
     """
+    # 计算下载路径
+    download_path = config.download_path
+    if dirname:
+        download_path = os.path.join(config.download_path, dirname)
+        os.makedirs(download_path, exist_ok=True)
+
     title = "%(title)s.%(ext)s"
     if name:
         title = f"{name}.%(ext)s"
@@ -215,7 +222,7 @@ async def download_one_music(config, url: str, name: str = ""):
         "--audio-quality",
         "0",
         "--paths",
-        config.download_path,
+        download_path,
         "-o",
         title,
         "--ffmpeg-location",


### PR DESCRIPTION
## 动机

当前 `/downloadonemusic` 接口只能下载到默认的 `download_path`，无法指定子目录。

而 `/downloadplaylist` 已经支持 `dirname` 参数，两个接口不一致。

## 改动

给 `/downloadonemusic` 接口增加可选的 `dirname` 参数，允许下载到子目录。

### Schema 变更

```python
class DownloadOneMusic(BaseModel):
    name: str = ""
    url: str
    dirname: str = ""  # 新增：子目录名（可选）
```

### 使用示例

```bash
# 下载到默认目录（向后兼容）
curl -X POST "http://localhost:8090/downloadonemusic" \
  -H "Content-Type: application/json" \
  -d '{"url": "https://example.com/song.mp3", "name": "测试歌曲"}'

# 下载到子目录
curl -X POST "http://localhost:8090/downloadonemusic" \
  -H "Content-Type: application/json" \
  -d '{"url": "https://example.com/song.mp3", "name": "测试歌曲", "dirname": "我的歌单"}'
```

## 改动文件

- `xiaomusic/api/models.py` - DownloadOneMusic 增加 dirname 字段
- `xiaomusic/utils/network_utils.py` - download_one_music() 支持 dirname 参数
- `xiaomusic/api/routers/file.py` - 接口传递 dirname 参数

## 向后兼容

`dirname` 默认为空字符串，不传时行为与之前一致。