### PR TITLE
fix(api): make /downloadonemusic dirname resolve under music_path

### DIFF
--- a/xiaomusic/utils/network_utils.py
+++ b/xiaomusic/utils/network_utils.py
@@ -191,7 +191,9 @@ async def download_playlist(config, url: str, dirname: str):
     return download_proc
 
 
-async def download_one_music(config, url: str, name: str = "", dirname: str = ""):
+async def download_one_music(
+    config, url: str, name: str = "", download_root: str | None = None
+):
     """
     下载单首歌曲
 
@@ -199,20 +201,16 @@ async def download_one_music(config, url: str, name: str = "", dirname: str = ""
         config: 配置对象
         url: 歌曲 URL
         name: 文件名（可选）
-        dirname: 子目录名（可选），相对于 download_path
+        download_root: 下载目录（可选），默认为 config.download_path
 
     Returns:
         下载进程对象
     """
-    # 计算下载路径
-    download_path = config.download_path
-    if dirname:
-        download_path = os.path.join(config.download_path, dirname)
-        os.makedirs(download_path, exist_ok=True)
-
     title = "%(title)s.%(ext)s"
     if name:
         title = f"{name}.%(ext)s"
+    download_root = download_root or config.download_path
+
     sbp_args = (
         "yt-dlp",
         "--no-playlist",
@@ -222,7 +220,7 @@ async def download_one_music(config, url: str, name: str = "", dirname: str = ""
         "--audio-quality",
         "0",
         "--paths",
-        download_path,
+        download_root,
         "-o",
         title,
         "--ffmpeg-location",


### PR DESCRIPTION
## 背景
当前 `/downloadonemusic` 的 `dirname` 语义会受 `download_path` 影响，前端若想稳定下载到 `music/<歌单目录>`，需要先改全局 `download_path`，不够直观。

## 改动
- `DownloadOneMusic` 增加 `dirname` 字段（向后兼容，默认空字符串）
- `downloadonemusic` 路由中：
  - 当传入 `dirname` 时，目标下载目录改为 `safe_join_path(config.music_path, dirname)`
  - 自动创建该目录（`os.makedirs(..., exist_ok=True)`）
  - 下载完成后按实际目标目录执行 `chmoddir`
- `download_one_music` 工具函数支持显式 `download_root` 参数（不传时仍使用 `config.download_path`）

## 行为变化
- 传 `dirname=周杰伦` 时，下载落到 `music/周杰伦`
- 不传 `dirname` 时，保持历史行为：仍落到 `download_path`

## 验证
- 本地真实接口测试：
  - `download_path` 设置为 `music/download`
  - 调用 `/downloadonemusic` 传 `dirname=__real_api_probe_20260211`
  - `/downloadlog` 中确认 `yt-dlp --paths music/__real_api_probe_20260211`
