### PR TITLE
feat(api): support playlist_name in /downloadonemusic

### DIFF
--- a/xiaomusic/api/models.py
+++ b/xiaomusic/api/models.py
@@ -57,6 +57,7 @@ class DownloadOneMusic(BaseModel):
     name: str = ""
     url: str
     dirname: str = ""
+    playlist_name: str = ""
 
 
 class PlayListObj(BaseModel):


### PR DESCRIPTION
## 背景
当前 POST /downloadonemusic 通过 dirname 传目录，语义偏文件夹，不利于前端按“歌单”表达业务。

## 变更
- DownloadOneMusic 新增可选字段 playlist_name
- 下载完成且成功后，后端自动：
  - 刷新音乐索引（gen_all_music_list + update_all_playlist）
  - 将本次下载歌曲自动加入 playlist_name 对应歌单（不存在则自动创建）
- 保留 dirname 兼容逻辑（不破坏现有调用）

## 行为说明
- 前端只需调用一次 /downloadonemusic 并传 playlist_name
- 不再依赖前端额外补一次 /playlistaddmusic
- 失败场景下不会误入歌单（仅在下载成功后执行关联）

## 兼容性
- 对旧调用方兼容：不传 playlist_name 时，行为与之前一致

## 备注
这个改动对应我们在 HMusic 侧的目标流程：“下载到歌单”由后端负责最终歌单关联，减少前端与下载异步任务之间的时序问题。
