### PR TITLE
fix: use short token proxy URL to avoid firmware URL length limit on Xiaomi speakers

### DIFF
--- a/xiaomusic/api/routers/file.py
+++ b/xiaomusic/api/routers/file.py
@@ -54,7 +54,7 @@ import secrets as _secrets
 
 # 短 token 缓存：避免长 URL 超出小爱音箱等设备固件的 URL 长度限制
 # key: token (str), value: (origin_url, is_radio)
-_proxy_token_cache: dict = {}
+from xiaomusic.music_library import _proxy_token_cache  # avoid circular import
 
 router = APIRouter()
 

--- a/xiaomusic/music_library.py
+++ b/xiaomusic/music_library.py
@@ -29,6 +29,9 @@ from xiaomusic.utils.music_utils import (
 from xiaomusic.utils.network_utils import MusicUrlCache
 from xiaomusic.utils.system_utils import try_add_access_control_param
 from xiaomusic.utils.text_utils import custom_sort_key, find_best_match, fuzzyfinder
+# 短 token 缓存，避免长 URL 超出小爱音箱固件限制（与 api/routers/file.py 共享）
+_proxy_token_cache: dict = {}  # token -> (origin_url, is_radio)
+
 
 
 class MusicLibrary:
@@ -1120,7 +1123,6 @@ class MusicLibrary:
         """
         import secrets
         try:
-            from xiaomusic.api.routers.file import _proxy_token_cache
             proxy_type = "radio" if is_radio else "music"
             token = secrets.token_urlsafe(8)
             _proxy_token_cache[token] = (origin_url, bool(is_radio))


### PR DESCRIPTION
## 问题描述

小爱音箱（如 LX06/小爱音箱Pro）在播放 bilibili 等在线音乐时，会提示"播放失败，请检查网络后再试"。

**根本原因：URL 过长超出固件 HTTP 客户端限制**

之前的实现将完整的 plugin-url（本身已包含大量 base64 编码的 JSON）再次进行 base64 编码后作为查询参数拼接，最终推送给音箱的 URL 长达 1500+ 字符，超出小爱音箱固件 HTTP 客户端约 1024 字节的 URL 长度限制，导致请求被截断，服务端返回 400，音箱报播放失败。

## 修复方案

引入短 token 缓存机制：

- **`music_library.py`**：`_get_proxy_url` 使用 `secrets.token_urlsafe(8)` 生成短 token，将原始 URL 存入内存字典 `_proxy_token_cache`，返回形如 `/proxy/music?token=xxxxxxxxxx` 的短 URL（约 60 字符）
- **`api/routers/file.py`**：`/proxy/{type}` 路由新增可选 `token` 参数，存在时从缓存查找原始 URL 进行代理；保留 `urlb64` 模式向后兼容
- token 不在首次使用后删除，允许音箱和 ffprobe 对同一首歌多次请求

## 测试

在 LX06（小爱音箱Pro）+ bilibili 插件环境下验证：
- 修复前：音箱请求 `/proxy/music?urlb64=<1500字符>` 返回 400，播放失败
- 修复后：音箱请求 `/proxy/music?token=<10字符>` 返回 200，播放正常
