### PR TITLE
Fix/proxy url too long for xiaomi speaker

### DIFF
--- a/xiaomusic/api/routers/file.py
+++ b/xiaomusic/api/routers/file.py
@@ -49,14 +49,7 @@ from xiaomusic.utils.network_utils import (
     downloadfile,
 )
 from xiaomusic.utils.system_utils import try_add_access_control_param
-import secrets as _secrets
-
-# 短 token 缓存，避免长 URL 超出小爱音箱固件限制
-import time as _time
-_proxy_token_cache: dict = {}  # token -> (origin_url, is_radio)
-
-def _cleanup_token_cache():
-    pass  # token 在重启时自动清空，无需持久化清理
+from xiaomusic.music_library import get_proxy_token
 
 router = APIRouter()
 
@@ -668,9 +661,10 @@ async def proxy_with_type(type: str, urlb64: str = "", token: str = ""):
 
     # token 短链模式
     if token:
-        if token not in _proxy_token_cache:
+        cached = get_proxy_token(token)
+        if cached is None:
             raise HTTPException(status_code=404, detail="token 已过期或不存在")
-        real_url, is_radio = _proxy_token_cache[token]
+        real_url, is_radio = cached
         # 不删除 token，允许音箱和 ffprobe 多次请求同一首歌
         import base64 as _b64
         urlb64 = _b64.b64encode(real_url.encode("utf-8")).decode("utf-8")

--- a/xiaomusic/music_library.py
+++ b/xiaomusic/music_library.py
@@ -29,8 +29,18 @@ from xiaomusic.utils.music_utils import (
 from xiaomusic.utils.network_utils import MusicUrlCache
 from xiaomusic.utils.system_utils import try_add_access_control_param
 from xiaomusic.utils.text_utils import custom_sort_key, find_best_match, fuzzyfinder
-# 短 token 缓存，避免长 URL 超出小爱音箱固件限制（与 api/routers/file.py 共享）
+# 短 token 缓存，避免长 URL 超出小爱音箱固件限制
 _proxy_token_cache: dict = {}  # token -> (origin_url, is_radio)
+
+
+def set_proxy_token(token: str, origin_url: str, is_radio: bool) -> None:
+    """存储 token -> (origin_url, is_radio) 映射"""
+    _proxy_token_cache[token] = (origin_url, bool(is_radio))
+
+
+def get_proxy_token(token: str):
+    """查询 token 对应的 (origin_url, is_radio)，不存在返回 None"""
+    return _proxy_token_cache.get(token)
 
 
 
@@ -1125,7 +1135,7 @@ class MusicLibrary:
         try:
             proxy_type = "radio" if is_radio else "music"
             token = secrets.token_urlsafe(8)
-            _proxy_token_cache[token] = (origin_url, bool(is_radio))
+            set_proxy_token(token, origin_url, bool(is_radio))
             proxy_url = f"{self.config.hostname}:{self.config.public_port}/proxy/{proxy_type}?token={token}"
             self.log.info(f"Using token proxy url: {proxy_url}")
             return proxy_url


### PR DESCRIPTION
新增了FFmpeg解码为MP3格式播放，看看有其他影响没有
小爱音响PRO使用BILIBILI搜索测试没问题
总共解决了2个问题：
1.推流地址过长被音箱截断，导致播放失败，改为短连接解决。
2.播放格式不支持，通过FFmpeg解码为MP3格式播放