### PR TITLE
fix: 移除日志中敏感凭据的明文输出

### DIFF
--- a/xiaomusic/auth.py
+++ b/xiaomusic/auth.py
@@ -206,7 +206,7 @@ class AuthManager:
 
         with open(self.mi_token_home, encoding="utf-8") as f:
             user_data = json.loads(f.read())
-        self.log.info(f"get_cookie user_data:{user_data}")
+        self.log.info("get_cookie user_data loaded")
         user_id = user_data.get("userId")
         service_token = user_data.get("micoapi")[1]
         device_id = self.config.get_one_device_id()

--- a/xiaomusic/qrcode_login.py
+++ b/xiaomusic/qrcode_login.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import json
 import locale
+import os
 import random
 import time
 from datetime import datetime, timedelta
@@ -230,8 +231,8 @@ class MiJiaAPI:
         self.auth_data_path.parent.mkdir(parents=True, exist_ok=True)
         with open(self.auth_data_path, "w") as f:
             json.dump(self.auth_data, f, indent=2, ensure_ascii=False)
+        os.chmod(self.auth_data_path, 0o600)
         print(f"已保存认证数据到 {self.auth_data_path}")
-        print(f"认证数据: {self.auth_data}")
 
     def _get_location(self) -> dict:
         headers = {
@@ -433,7 +434,6 @@ class MiJiaAPI:
         return self.auth_data
 
     def _request(self, uri: str, data: dict, refresh_token: bool = True) -> dict:
-        print(f"请求 URI: {uri}，数据: {data}")
         if refresh_token:
             self._refresh_token()
         url = self.api_base_url + uri
@@ -449,7 +449,6 @@ class MiJiaAPI:
         except json.JSONDecodeError:
             dec_data = decrypt(self.auth_data["ssecurity"], nonce, ret.text)
             ret_data = json.loads(dec_data)
-        print(f"响应数据: {ret_data}")
         if ret_data.get("code", 0) != 0 or "result" not in ret_data:
             raise ValueError(
                 f"API错误，状态码: {ret_data['code']}, 响应: {ret_data.get('message', ret_data.get('desc', '未知错误'))}"


### PR DESCRIPTION
## Summary
- 删除 `_save_auth_data()` 中 `print(f"认证数据: {self.auth_data}")`，该行会将 passToken、ssecurity、serviceToken 等完整凭据打印到 stdout/docker logs
- 删除 `_request()` 中打印请求数据和响应数据的 print，避免泄露 API 交互细节
- `auth.py` 的 `get_cookie()` 日志不再输出 `.mi.token` 文件完整内容（含 serviceToken），改为仅记录加载成功
- `auth.json` 写入后设置 `0600` 文件权限，防止同机其他用户读取

## 背景
目前已有用户在 issue 中贴出日志时无意暴露了小米账号信息（如 #681、#575）。虽然这些案例主要来自上游 miservice 库的异常日志，但 xiaomusic 自身的 `print(认证数据)` 会输出**完整的 token 和密钥**，风险更大——一旦用户贴出包含该行的日志，攻击者可完全控制其小米账号下的所有 IoT 设备。

## Test plan
- [ ] QR 扫码登录流程正常，auth.json 正常保存
- [ ] auth.json 文件权限为 600
- [ ] docker logs 中不再出现 passToken/ssecurity 等敏感字段
- [ ] `_request()` API 调用正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)