### PR TITLE
feat: 启用安全访问后，增加cookie

### DIFF
--- a/xiaomusic/api/dependencies.py
+++ b/xiaomusic/api/dependencies.py
@@ -2,15 +2,18 @@
 
 import hashlib
 import secrets
+import time  # 🚀 新增：用于生成 7 天免密 Cookie 的过期时间（exp）
 from typing import (
     TYPE_CHECKING,
     Annotated,
 )
 
+import jwt  # 🚀 新增：用于生成和验证 JWT Token
 from fastapi import (
     Depends,
     HTTPException,
     Request,
+    Response,  # 🚀 新增：引入 Response 用于写入 Cookie
     status,
 )
 from fastapi.security import (
@@ -25,7 +28,8 @@ if TYPE_CHECKING:
     from xiaomusic.config import Config
     from xiaomusic.xiaomusic import XiaoMusic
 
-security = HTTPBasic()
+# 🚀 修改：关闭基础认证的自动抛错，让我们接管验证流程
+security = HTTPBasic(auto_error=False)
 
 
 class _AppStateProxy:
@@ -100,10 +104,38 @@ config: "Config" = _LazyProxy("_config")  # type: ignore
 log: "logging.Logger" = _LazyProxy("_log")  # type: ignore
 
 
+# 🚀 修改：增加了 request 和 response 参数以操作 Cookie，并将 credentials 设为 Optional
 def verification(
-    credentials: Annotated[HTTPBasicCredentials, Depends(security)],
+    request: Request,
+    response: Response,
+    credentials: Annotated[HTTPBasicCredentials | None, Depends(security)],
 ):
     """HTTP Basic 认证"""
+    # ========================================================
+    # 🚀 新增：7天免密模块 开始 (API拦截层)
+    # ========================================================
+    if config.disable_httpauth:
+        return True
+
+    session_secret = hashlib.sha256(config.httpauth_password.encode()).hexdigest()
+    cookie_name = "xiaomusic_auth_session"
+
+    token = request.cookies.get(cookie_name)
+    if token:
+        try:
+            jwt.decode(token, session_secret, algorithms=["HS256"])
+            return True
+        except:
+            pass
+
+    if not credentials:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    # ========================================================
+
     current_username_bytes = credentials.username.encode("utf8")
     correct_username_bytes = config.httpauth_username.encode("utf8")
     is_correct_username = secrets.compare_digest(
@@ -120,6 +152,17 @@ def verification(
             detail="Incorrect username or password",
             headers={"WWW-Authenticate": "Basic"},
         )
+
+    # ========================================================
+    # 🚀 新增：验证成功后，在此处派发持久化 Cookie
+    # ========================================================
+    expire_time = time.time() + 60 * 60 * 24 * 7
+    payload = {"sub": credentials.username, "exp": expire_time}
+    new_token = jwt.encode(payload, session_secret, algorithm="HS256")
+    response.set_cookie(
+        key=cookie_name, value=new_token, max_age=60 * 60 * 24 * 7, httponly=True, samesite="lax"
+    )
+    # ========================================================
     return True
 
 
@@ -170,7 +213,42 @@ class AuthStaticFiles(StaticFiles):
     async def __call__(self, scope, receive, send) -> None:
         request = Request(scope, receive)
         if not config.disable_httpauth:
-            assert verification(await security(request))
+            # ========================================================
+            # 🚀 新增：7天免密模块 开始 (网页静态文件拦截层)
+            # ========================================================
+            session_secret = hashlib.sha256(config.httpauth_password.encode()).hexdigest()
+            cookie_name = "xiaomusic_auth_session"
+            token = request.cookies.get(cookie_name)
+            is_authed = False
+
+            if token:
+                try:
+                    jwt.decode(token, session_secret, algorithms=["HS256"])
+                    is_authed = True
+                except:
+                    pass
+
+            if not is_authed:
+                credentials = await security(request)
+                if not credentials:
+                    response = Response(status_code=401, headers={"WWW-Authenticate": "Basic"})
+                    await response(scope, receive, send)
+                    return
+
+                current_username_bytes = credentials.username.encode("utf8")
+                correct_username_bytes = config.httpauth_username.encode("utf8")
+                is_correct_username = secrets.compare_digest(current_username_bytes, correct_username_bytes)
+                current_password_bytes = credentials.password.encode("utf8")
+                correct_password_bytes = config.httpauth_password.encode("utf8")
+                is_correct_password = secrets.compare_digest(current_password_bytes, correct_password_bytes)
+
+                if not (is_correct_username and is_correct_password):
+                    response = Response(status_code=401, headers={"WWW-Authenticate": "Basic"})
+                    await response(scope, receive, send)
+                    return
+            # ========================================================
+            # 原有的 assert verification 被上面的拦截取代，避免重复弹窗
+            pass
         await super().__call__(scope, receive, send)
 
 


### PR DESCRIPTION
开启安全访问后，FastAPI自带的用户名密码验证，每次开页面都会提示输入账号。
但公网可访问的，又必须开启。
因此，增加cookie，默认一周验证失效。既保证安全，又不失便利性。