### PR TITLE
修补url的base64编码

### DIFF
--- a/xiaomusic/api/routers/music.py
+++ b/xiaomusic/api/routers/music.py
@@ -76,6 +76,13 @@ async def get_plugin_source_url(
 ):
     try:
         # 获取请求数据
+        # 容错处理1：将 URL 传输中可能被误转为空格的 '+' 还原回去（win平台）
+        data = data.replace(' ', '+')
+        # 2. 容错处理：自动补全 Base64 缺失的 '=' 填充符（Linux平台）
+        missing_padding = len(data) % 4
+        if missing_padding:
+            data += '=' * (4 - missing_padding)
+
         # 将Base64编码的URL解码为Json字符串
         json_str = base64.b64decode(data).decode("utf-8")
         # 将json字符串转换为json对象


### PR DESCRIPTION
主要修补2块
1. data = data.replace(' ', '+')  # 针对win平台
<img width="2074" height="294" alt="image" src="https://github.com/user-attachments/assets/4b1889d8-1264-485e-a168-396c69c8727b" />


2. 补齐缺失的=，针对Linux平台
<img width="1582" height="172" alt="image" src="https://github.com/user-attachments/assets/50e98963-68ac-44cf-ad30-726088416079" />
