### PR TITLE
首页上把“适配iPhone主题”修改了一下

### DIFF
--- a/xiaomusic/static/index.html
+++ b/xiaomusic/static/index.html
@@ -64,7 +64,10 @@
         <a href="/static/onlineSearch/index.html">OnlineSearch</a>
       </div>
       <div class="options_list">
-        <a href="/static/iwebplayer/iwebplayer.html">适配iPhone主题</a>
+        <a href="/static/iwebplayer/iwebplayer.html" style="flex-direction: column; line-height: 1.2; padding: 4px 0; letter-spacing: 0;">
+          <span style="font-weight: 600;">iWebPlayer</span>
+          <span style="font-size: 0.7em; opacity: 0.7; margin-top: 2px;">iPhone手机播放器</span>
+        </a>
       </div>
       <div class="options_list weapp">
         <a href="https://github.com/F-loat/xiaoplayer" target="_blank">微信小程序</a>


### PR DESCRIPTION
iWebPlayer经过多次更新，在iPhone手机上，已经非常接近原生app了。因此，改一下名字。谢谢。