### PR TITLE
当XiaoMusic设置中语音TTS设为不使用，语音关机小爱音箱，会导致token失效

### DIFF
--- a/xiaomusic/device_player.py
+++ b/xiaomusic/device_player.py
@@ -606,8 +606,11 @@ class XiaoMusicDevice:
     async def text_to_speech(self, value):
         """文字转语音"""
         try:
+            # 检查设置中是否启用了语音TTS。如果是关闭，直接退出，避免后续走到小米TTS，导致token失效
+            if self.config.edge_tts_voice == "disable":
+                return
             # 检查是否配置了 edge-tts 语音角色
-            if self.config.edge_tts_voice:
+            elif self.config.edge_tts_voice:
                 await self._text_to_speech_edge_tts(value)
             else:
                 # 使用原有的 TTS 逻辑

--- a/xiaomusic/static/default/setting.html
+++ b/xiaomusic/static/default/setting.html
@@ -307,7 +307,7 @@
                     <div class="rows">
                         <label for="edge_tts_voice">Edge-TTS 语音角色:</label>
                         <select id="edge_tts_voice">
-                            <option value="">不使用(默认)</option>
+                            <option value="disable">不使用(默认)</option>
                             <option value="zh-CN-XiaoxiaoNeural">晓晓 (女声,温柔)</option>
                             <option value="zh-CN-XiaoyiNeural" selected>
                                 晓伊 (女声,活泼)


### PR DESCRIPTION
如题。

当XiaoMusic设置中语音TTS设为不使用。
小爱音箱正常播放音乐，喊“关机”后，就再也无法连上了。

以下是相关的日志。
可以看到"收到消息:关机" → "try do_tts value:收到,再见" → 由于不使用语音TTS，跳过edge-tts，触发小米的TTS，"Call MiIOService tts" → 然后可能引用底层的miioservice，触发了" Login failed" → 最终导致token失效，再也无法控制小爱音箱。

[2026-04-10 19:37:53] [0.5.0] [INFO] command_handler.py:51: 收到消息:关机 控制面板:False did:635055981
[2026-04-10 19:37:53] [0.5.0] [INFO] command_handler.py:94: 完全匹配指令. query:关机 opvalue:stop
[2026-04-10 19:37:53] [0.5.0] [INFO] device_player.py:406: try do_tts value:收到,再见
[2026-04-10 19:37:53] [0.5.0] [INFO] device_player.py:617: Call MiIOService tts.
[2026-04-10 19:37:54] [0.5.0] [ERROR] device_player.py:630: Execption Error https://api.io.mi.com/app/miotspec/action: Login failed
Traceback (most recent call last):
  File "C:\Work\WEB\python312\xiaomusic-0.4.23\xiaomusic\device_player.py", line 619, in text_to_speech
    await miio_command(
  File "C:\Users\Frank.Ni\AppData\Local\Programs\Python\Python312\Lib\site-packages\miservice\miiocommand.py", line 113, in miio_command
    return await service.miot_action(did, props[0], args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Frank.Ni\AppData\Local\Programs\Python\Python312\Lib\site-packages\miservice\miioservice.py", line 87, in miot_action
    result = await self.miot_request(
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Frank.Ni\AppData\Local\Programs\Python\Python312\Lib\site-packages\miservice\miioservice.py", line 66, in miot_request
    return await self.miio_request("/miotspec/" + cmd, {"params": params})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Frank.Ni\AppData\Local\Programs\Python\Python312\Lib\site-packages\miservice\miioservice.py", line 30, in miio_request
    resp = await self.account.mi_request(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Frank.Ni\AppData\Local\Programs\Python\Python312\Lib\site-packages\miservice\miaccount.py", line 155, in mi_request
    raise Exception(f"Error {url}: {resp}")
Exception: Error https://api.io.mi.com/app/miotspec/action: Login failed
[2026-04-10 19:37:55] [0.5.0] [INFO] device_player.py:417: do_tts ok. cur_music:明天的明天的明天-动力火车
[2026-04-10 19:37:55] [0.5.0] [INFO] device_player.py:524: 不会继续播放歌曲. isplaying:False isdownloading:False
[2026-04-10 19:37:58] [0.5.0] [INFO] device_player.py:928: cancel_group_next_timer {'635055981': <xiaomusic.device_player.XiaoMusicDevice object at 0x0000023CC5973F80>}
[2026-04-10 19:37:58] [0.5.0] [INFO] device_player.py:913: cancel_next_timer did: 635055981
[2026-04-10 19:37:58] [0.5.0] [INFO] device_player.py:920: 下一曲定时器已取消 did: 635055981
[2026-04-10 19:37:58] [0.5.0] [INFO] device_player.py:888: group_force_stop_xiaoai 小爱音箱Play增强版 ['da1aa656-8c4f-4cdd-967d-618ed9b74a74']
[2026-04-10 19:37:58] [0.5.0] [WARNING] device_player.py:429: Execption Error https://api2.mina.mi.com/remote/ubus: Login failed
[2026-04-10 19:37:58] [0.5.0] [INFO] device_player.py:891: group_force_stop_xiaoai ['da1aa656-8c4f-4cdd-967d-618ed9b74a74'] [None]
[2026-04-10 19:37:58] [0.5.0] [INFO] device_player.py:881: stop now
[2026-04-10 19:39:34] [0.5.0] [INFO] 192.168.199.23:7051 - "GET /static/default/setting.html HTTP/1.1" 304
[2026-04-10 19:39:35] [0.5.0] [INFO] 192.168.199.23:7051 - "GET /getversion HTTP/1.1" 200
[2026-04-10 19:39:36] [0.5.0] [WARNING] xiaomusic.py:653: Execption Error https://api2.mina.mi.com/admin/v2/device_list?master=0&requestId=app_ios_8k4KnBijSmval0RPsg5JqxW31rQtFh: Login failed
[2026-04-10 19:39:37] [0.5.0] [WARNING] auth.py:103: 可能登录失败. Error https://api2.mina.mi.com/admin/v2/device_list?master=0&requestId=app_ios_OWzC5uyARvI7fVa8JPw3psDbQ0KSdq: Login failed
[2026-04-10 19:39:37] [0.5.0] [INFO] auth.py:65: try login
[2026-04-10 19:39:37] [0.5.0] [INFO] auth.py:126: 登录完成. 1348736542
[2026-04-10 19:39:37] [0.5.0] [WARNING] auth.py:164: 可能登录失败. Error https://api2.mina.mi.com/admin/v2/device_list?master=0&requestId=app_ios_kRyjxQKnTqLDVoUzAaBcPGu162rO0t: Login failed
[2026-04-10 19:39:37] [0.5.0] [INFO] device_player.py:938: in cancel_all_timer


我修改了2给地方
前端setting.html：不使用语言TTS，增加value值为“disable”
后端device_player.py：判断config.edge_tts_voic是disable，直接跳过语音。后续代码不变。

经过改动后，bug修复。