### PR TITLE
后台自动切换MusicFree插件/LX Server接口

### DIFF
--- a/xiaomusic/api/routers/music.py
+++ b/xiaomusic/api/routers/music.py
@@ -42,6 +42,7 @@ async def search_online_music(
     plugin: str = Query("all", description="指定插件名称，all表示搜索所有插件"),
     page: int = Query(1, description="页码"),
     limit: int = Query(20, description="每页数量"),
+    api_type: int = Query(None, description="接口类型：1=MusicFree，2=LXServer"),  # 🌟 接收前端传来的 api_type
 ):
     """在线音乐搜索API"""
     try:
@@ -49,7 +50,7 @@ async def search_online_music(
             return {"success": False, "error": "Keyword required"}
 
         return await xiaomusic.get_music_list_online(
-            keyword=keyword, plugin=plugin, page=page, limit=limit
+            keyword=keyword, plugin=plugin, page=page, limit=limit, api_type=api_type
         )
     except Exception as e:
         return {"success": False, "error": str(e)}

--- a/xiaomusic/js_plugin_manager.py
+++ b/xiaomusic/js_plugin_manager.py
@@ -1032,8 +1032,14 @@ class JSPluginManager:
         except Exception:
             return 1
 
-    def is_lx_server(self) -> bool:
+    def is_lx_server(self, context_info=None) -> bool:
         """判定是否使用lx_server接口"""
+        if context_info and isinstance(context_info, dict):
+            # 目前判断：有 _raw 就是 LX
+            if "_raw" in context_info:
+                return True
+            # 没有就是MusicFree
+            return False
         return self._get_api_type() == 2
 
     def get_platforms(self) -> dict[Any, Any]:

--- a/xiaomusic/online_music.py
+++ b/xiaomusic/online_music.py
@@ -61,7 +61,7 @@ class OnlineMusicService:
         self._singer_add_page = 1
 
     async def get_music_list_online(
-        self, plugin="all", keyword="", page=1, limit=20, **kwargs
+        self, plugin="all", keyword="", page=1, limit=20, api_type=None, **kwargs
     ):
         """在线获取歌曲列表
 
@@ -83,7 +83,12 @@ class OnlineMusicService:
         keyword, artist = await self._parse_keyword_and_artist(keyword)
 
         # 获取API配置信息
-        is_lx_server = self.js_plugin_manager.is_lx_server()
+        # 🌟 根据前端传入的 api_type 判断，1为MF插件，2为LX接口。如果没有传则用老办法兜底
+        if api_type is not None:
+            is_lx_server = (int(api_type) == 2)
+        else:
+            is_lx_server = self.js_plugin_manager.is_lx_server()
+
         if is_lx_server:
             # LX Server在线搜索
             return await self._execute_lx_server_search(
@@ -768,8 +773,8 @@ class OnlineMusicService:
         Returns:
             dict: 包含成功状态和URL信息的字典
         """
-        # 判断接口类型
-        is_lx_server = self.js_plugin_manager.is_lx_server()
+        # 🌟 自动判断接口类型
+        is_lx_server = self.js_plugin_manager.is_lx_server(context_info=music_item)
         if is_lx_server:
             # LX Server在线搜索
             return await self._execute_lx_server_music_url(
@@ -796,8 +801,8 @@ class OnlineMusicService:
         Returns:
             dict: 包含成功状态和歌词信息的字典
         """
-        # 判断接口类型
-        is_lx_server = self.js_plugin_manager.is_lx_server()
+        # 🌟 自动判断接口类型
+        is_lx_server = self.js_plugin_manager.is_lx_server(context_info=music_item)
         if is_lx_server:
             # LX Server在线搜索
             return await self._execute_lx_server_music_lyric(


### PR DESCRIPTION
1. 本机/小爱播放的时候，根据获取的源，自动调用后台MusicFree插件/LX Server接口（查看源里面有没有key "_raw"，有就是LX）
2. 本机搜索的时候，新增传参api_type。api_type: int = Query(None, description="接口类型：1=MusicFree，2=LXServer")
3. 原有逻辑都保留，兜底是配置文件中的api_type