### PR TITLE
修复LX歌单转XiaoMusic歌单，转换后某些平台无法播放的问题

### DIFF
--- a/xiaomusic/js_plugin_manager.py
+++ b/xiaomusic/js_plugin_manager.py
@@ -1898,11 +1898,10 @@ class JSPluginManager:
                 img = (
                     song.get("img", "") or meta.get("picUrl", "") or meta.get("img", "")
                 )
-                songmid = (
-                    song.get("songmid", "")
-                    or song.get("id", "")
-                    or meta.get("songId", "")
-                )
+
+                # 改成获取内层的songId。tx的内层是id
+                songmid = meta.get("songId", "") or meta.get("id", "")
+
                 types = song.get("types", []) or meta.get("qualitys", []) or []
                 _types = song.get("_types", {}) or meta.get("_qualitys", {}) or {}
 
@@ -1925,6 +1924,11 @@ class JSPluginManager:
                     "_types": _types,
                     "typeUrl": {},
                 }
+
+                #  kg还需要加hash
+                song_hash = meta.get("hash", "")
+                if song_hash:
+                    raw_info["hash"] = song_hash
 
                 song_info = {
                     "_raw": raw_info,


### PR DESCRIPTION
kg平台，需要增加“hash”这个额外的key
有些平台，songmid需要纯数字的，因此改成从lx的返回“meta”中获取
在lx v1.8.3和v1.9.0测试通过。