### PR TITLE
修复某些MusicFree插件，从歌单获取的歌曲数不足

### DIFF
--- a/xiaomusic/js_plugin_manager.py
+++ b/xiaomusic/js_plugin_manager.py
@@ -2246,6 +2246,7 @@ class JSPluginManager:
                 "action": "getMusicSheetInfo",
                 "pluginName": plugin_name,
                 "playlistInfo": playlist_info,
+                "page": page,
             }
         )
 
@@ -2684,18 +2685,41 @@ class JSPluginManager:
             json_str = base64.b64decode(b64_id).decode("utf-8")
             playlist_info = json.loads(json_str)
 
-            # 3. 调用插件获取歌曲列表
-            result = self.get_music_sheet_info(plugin_name, playlist_info, page=1)
+            data_list = []
+            current_page = 1
+            max_pages = 50  # 设置安全阈值，防止插件Bug导致死循环（最多拿1000~1500首歌）
 
-            if not result or not result.get("musicList"):
+            # 3. 循环翻页，直到拿完所有歌曲
+            while current_page <= max_pages:
+                self.log.info(f"正在获取 {plugin_name} 歌单详情，第 {current_page} 页...")
+
+                result = self.get_music_sheet_info(plugin_name, playlist_info, page=current_page)
+
+                if not result or not result.get("musicList"):
+                    break
+
+                page_data = result.get("musicList", [])
+                if not page_data:
+                    break
+
+                data_list.extend(page_data)
+
+                # 判断插件是否返回了结束标志
+                is_end = result.get("isEnd", True)
+                if is_end:
+                    break
+
+                current_page += 1
+
+            if not data_list:
                 return {"success": False, "error": "歌单解析为空或格式不支持", "data": []}
-
-            data_list = result.get("musicList", [])
 
             # 4. 补齐平台字段，确保后端播歌逻辑能识别来源
             for item in data_list:
                 if "platform" not in item:
                     item["platform"] = plugin_name
+
+            self.log.info(f"歌单全量拉取完成，共 {len(data_list)} 首歌。")
 
             return {
                 "success": True,

--- a/xiaomusic/js_plugin_runner.js
+++ b/xiaomusic/js_plugin_runner.js
@@ -78,7 +78,7 @@ class PluginRunner {
                     result = await this.getAlbum(message.pluginName, message.albumInfo);
                     break;
                 case 'getMusicSheetInfo':
-                    result = await this.getPlaylist(message.pluginName, message.playlistInfo);
+                    result = await this.getPlaylist(message.pluginName, message.playlistInfo, message.page);
                     break;
                 case 'getArtistWorks':
                     result = await this.getArtistWorks(message.pluginName, message.artistItem, message.page, message.type);
@@ -412,7 +412,7 @@ class PluginRunner {
         }
     }
 
-    async getPlaylist(pluginName, playlistInfo) {
+    async getPlaylist(pluginName, playlistInfo, page = 1) {
         const plugin = this.plugins.get(pluginName);
         if (!plugin) {
             throw new Error(`Plugin ${pluginName} not found`);
@@ -425,8 +425,8 @@ class PluginRunner {
         }
 
         try {
-            // 使用默认页码 1（从MusicFree官方文档得知默认为1）
-            const result = await plugin.getMusicSheetInfo(playlistInfo, 1);
+            // 换成动态的 page 变量
+            const result = await plugin.getMusicSheetInfo(playlistInfo, page);
             // 参考 MusicFree 实现，验证结果
             if (result === null || result === undefined) {
                 return null;


### PR DESCRIPTION
主要修改js_plugin_runner.js中const result = await plugin.getMusicSheetInfo(playlistInfo, 1);
原本写死的第1页，改成动态的页数。
这样就能从歌单中获取到所有的歌曲了。