### PR TITLE
增加搜索成功后的语音提示选择

### DIFF
--- a/xiaomusic/config.py
+++ b/xiaomusic/config.py
@@ -220,6 +220,9 @@ class Config:
     play_type_seq_tts_msg: str = os.getenv(
         "XIAOMUSIC_PLAY_TYPE_SEQ_TTS_MSG", "已经设置为顺序播放"
     )
+    search_prompt_audio: str = os.getenv(
+        "XIAOMUSIC_SEARCH_PROMPT_AUDIO", "xiaomusic_ok.mp3"
+    )
     recently_added_playlist_len: int = int(
         os.getenv("XIAOMUSIC_RECENTLY_ADDED_PLAYLIST_LEN", "50")
     )

--- a/xiaomusic/online_music.py
+++ b/xiaomusic/online_music.py
@@ -820,8 +820,12 @@ class OnlineMusicService:
         # return proxy_base + "/static/search.mp3"
         return f"{proxy_base}/static/{name}"
 
-    async def _before_play(self, prompt_audio="xiaomusic_ok.mp3"):
-        # 先推送默认【搜索中】音频，搜索到播放url后推送给小爱
+    async def _before_play(self, prompt_audio=None):
+        """播放搜歌前的提示音或静默音（核心作用：打断小爱的原生语音）"""
+        if prompt_audio is None:
+            prompt_audio = getattr(
+                self.xiaomusic.config, "search_prompt_audio", "xiaomusic_ok.mp3"
+            )
         before_url = self.default_url(prompt_audio)
         await self.xiaomusic.play_url(self.xiaomusic.get_cur_did(), before_url)
 

--- a/xiaomusic/static/default/setting.html
+++ b/xiaomusic/static/default/setting.html
@@ -330,7 +330,7 @@
                             <option value="zh-TW-HsiaoYuNeural">曉雨 (女声,台湾)</option>
                         </select>
 
-                        <label for="stop_tts_msg">停止提示音:</label>
+                        <label for="stop_tts_msg">停止提示音 (触屏音箱建议留空):</label>
                         <input id="stop_tts_msg" type="text" value="收到,再见" />
 
                         <label for="play_type_one_tts_msg">单曲循环提示音:</label>
@@ -347,6 +347,12 @@
 
                         <label for="play_type_seq_tts_msg">顺序播放提示音:</label>
                         <input id="play_type_seq_tts_msg" type="text" value="已经设置为顺序播放" />
+
+                        <label for="search_prompt_audio">搜索成功，语音提示:</label>
+                        <select id="search_prompt_audio">
+                            <option value="xiaomusic_ok.mp3" selected>xiaomusic_ok.mp3 ("小Music收到")</option>
+                            <option value="silence.mp3">silence.mp3 (静默)</option>
+                        </select>
                     </div>
                     </div>
                 </div>


### PR DESCRIPTION
核心作用：打断小爱的原生语音。可选择语音静默或“小Music收到”
有人喜欢清净，有人喜欢有回应^0^。所以增加一个选项配置