### PR TITLE
fix: 修复 Python 3.10 环境下 asyncio.timeout 导致的 AttributeError

### DIFF
--- a/xiaomusic/auth.py
+++ b/xiaomusic/auth.py
@@ -53,11 +53,16 @@ class AuthManager:
 
     async def init_all_data(self, force_login=False):
         try:
-            async with asyncio.timeout(INIT_LOCK_TIMEOUT_SEC):
-                async with self._init_lock:
-                    await self._init_all_data_impl(force_login)
+            await asyncio.wait_for(
+                self._init_all_data_with_lock(force_login),
+                timeout=INIT_LOCK_TIMEOUT_SEC,
+            )
         except asyncio.TimeoutError:
             self.log.warning("init_all_data 超时，可能被其他调用持有锁")
+
+    async def _init_all_data_with_lock(self, force_login=False):
+        async with self._init_lock:
+            await self._init_all_data_impl(force_login)
 
     async def _init_all_data_impl(self, force_login=False):
         self.mi_token_home = os.path.join(self.config.conf_path, ".mi.token")


### PR DESCRIPTION
- asyncio.timeout 是 Python 3.11+ 特性，在 3.10 会报错
- 替换为 asyncio.wait_for 以向下兼容旧版本 Python
- 抽离 _init_all_data_with_lock 函数以配合 wait_for 使用