### PR TITLE
修复循环播放tts语音的问题之一

### DIFF
--- a/xiaomusic/device_player.py
+++ b/xiaomusic/device_player.py
@@ -950,7 +950,8 @@ class XiaoMusicDevice:
             if duration > 0:
 
                 async def _tts_timeout():
-                    await asyncio.sleep(duration)
+                    # 增加2秒，确保小爱音箱缓存完毕后，触发后续stop
+                    await asyncio.sleep(duration + 2)
                     try:
                         self.log.info("TTS 播放定时器时间到")
                         current_timer = self._tts_timer


### PR DESCRIPTION
修复循环播放tts语音的问题之一
这次是发现网络传输慢，或音箱性能差的时候，音箱还没完全加载好tts的mp3文件。xiaomusic就触发stop了。最终音箱就会循环播放tts语音了。
