### PR TITLE
增加触屏版封面选择，修改部分默认设置

### DIFF
--- a/xiaomusic/config.py
+++ b/xiaomusic/config.py
@@ -134,7 +134,7 @@ class Config:
         os.getenv("XIAOMUSIC_USE_MUSIC_API", "false").lower() == "true"
     )
     use_music_audio_id: str = os.getenv(
-        "XIAOMUSIC_USE_MUSIC_AUDIO_ID", "3569278039160259547"
+        "XIAOMUSIC_USE_MUSIC_AUDIO_ID", "436490277987655"
     )
     use_music_id: str = os.getenv("XIAOMUSIC_USE_MUSIC_ID", "355454500")
     log_file: str = os.getenv("XIAOMUSIC_LOG_FILE", "xiaomusic.log.txt")

--- a/xiaomusic/config.py
+++ b/xiaomusic/config.py
@@ -97,6 +97,7 @@ class Config:
     conf_path: str = os.getenv("XIAOMUSIC_CONF_PATH", "conf")
     cache_dir: str = os.getenv("XIAOMUSIC_CACHE_DIR", "music/cache")
     cache_max_size_mb: int = int(os.getenv("XIAOMUSIC_CACHE_MAX_SIZE_MB", "500"))
+    cache_song_name: str = os.getenv("XIAOMUSIC_CACHE_SONG_NAME", "cache_songs")
     hostname: str = os.getenv("XIAOMUSIC_HOSTNAME", "http://192.168.2.5")
     port: int = int(os.getenv("XIAOMUSIC_PORT", "8090"))  # 监听端口
     public_port: int = int(os.getenv("XIAOMUSIC_PUBLIC_PORT", 58090))  # 歌曲访问端口
@@ -133,7 +134,7 @@ class Config:
         os.getenv("XIAOMUSIC_USE_MUSIC_API", "false").lower() == "true"
     )
     use_music_audio_id: str = os.getenv(
-        "XIAOMUSIC_USE_MUSIC_AUDIO_ID", "1582971365183456177"
+        "XIAOMUSIC_USE_MUSIC_AUDIO_ID", "3569278039160259547"
     )
     use_music_id: str = os.getenv("XIAOMUSIC_USE_MUSIC_ID", "355454500")
     log_file: str = os.getenv("XIAOMUSIC_LOG_FILE", "xiaomusic.log.txt")
@@ -153,19 +154,25 @@ class Config:
     )
     # 多结果处理方式: random=随机播放, first=从第一个开始播放
     multi_result_action: str = os.getenv("XIAOMUSIC_MULTI_RESULT_ACTION", "random")
-    stop_tts_msg: str = os.getenv("XIAOMUSIC_STOP_TTS_MSG", "收到,再见")
+    stop_tts_msg: str = os.getenv("XIAOMUSIC_STOP_TTS_MSG", "")
     enable_config_example: bool = False
 
     keywords_playlocal: str = os.getenv(
         "XIAOMUSIC_KEYWORDS_PLAYLOCAL", "播放本地歌曲,本地播放歌曲"
     )
     keywords_play: str = os.getenv("XIAOMUSIC_KEYWORDS_PLAY", "播放歌曲,放歌曲")
-    keywords_online_play: str = os.getenv("XIAOMUSIC_KEYWORDS_ONLINE_PLAY", "在线播放")
+    keywords_online_play: str = os.getenv(
+        "XIAOMUSIC_KEYWORDS_ONLINE_PLAY", "在线播放,搜索歌曲"
+    )
     keywords_online_playlist_play: str = os.getenv(
         "XIAOMUSIC_KEYWORDS_ONLINE_PLAYLIST", "在线歌单,搜索歌单"
     )
-    keywords_singer_play: str = os.getenv("XIAOMUSIC_KEYWORDS_SINGER_PLAY", "播放歌手")
-    keywords_stop: str = os.getenv("XIAOMUSIC_KEYWORDS_STOP", "关机,暂停,停止,停止播放")
+    keywords_singer_play: str = os.getenv(
+        "XIAOMUSIC_KEYWORDS_SINGER_PLAY", "播放歌手,搜索歌手"
+    )
+    keywords_stop: str = os.getenv(
+        "XIAOMUSIC_KEYWORDS_STOP", "关机,暂停,停止,停止播放,关闭,退出,关掉音乐"
+    )
     keywords_playlist: str = os.getenv(
         "XIAOMUSIC_KEYWORDS_PLAYLIST", "播放列表,播放歌单"
     )
@@ -184,9 +191,7 @@ class Config:
     )
     convert_to_mp3: bool = os.getenv("CONVERT_TO_MP3", "false").lower() == "true"
     delay_sec: int = int(os.getenv("XIAOMUSIC_DELAY_SEC", 0))  # 下一首歌延迟播放秒数
-    continue_play: bool = (
-        os.getenv("XIAOMUSIC_CONTINUE_PLAY", "false").lower() == "true"
-    )
+    continue_play: bool = os.getenv("XIAOMUSIC_CONTINUE_PLAY", "true").lower() == "true"
     # 目录监控配置
     enable_file_watch: bool = (
         os.getenv("XIAOMUSIC_ENABLE_FILE_WATCH", "false").lower() == "true"

--- a/xiaomusic/music_library.py
+++ b/xiaomusic/music_library.py
@@ -829,7 +829,9 @@ class MusicLibrary:
                     )
 
                 # 将纠正后的 actual_cache_dir 传给底层
-                return build_cache_file_path(datab64, name, actual_cache_dir)
+                return build_cache_file_path(
+                    datab64, name, actual_cache_dir, self.config.cache_song_name
+                )
         except Exception as e:
             self.log.debug(f"提取缓存路径失败: {e}")
         return ""
@@ -945,6 +947,7 @@ class MusicLibrary:
                             clean_old_caches,
                             self.config.cache_dir,
                             getattr(self.config, "cache_max_size_mb", 0),
+                            self.config.cache_song_name,
                         )
                     )
                     cleanup_task.add_done_callback(lambda t: t.exception())

--- a/xiaomusic/static/default/setting.html
+++ b/xiaomusic/static/default/setting.html
@@ -232,23 +232,44 @@
                         <label for="delay_sec">下一首歌延迟播放秒数(支持负数):</label>
                         <input id="delay_sec" type="number" value="0" />
 
-                        <label for="continue_play">启用继续播放，启用触屏音箱歌曲封面及歌词(可能导致兼容性问题):</label>
-                        <select id="continue_play">
-                            <option value="true">true</option>
-                            <option value="false" selected>false</option>
-                        </select>
-
                         <label for="use_music_api">型号兼容模式:</label>
                         <select id="use_music_api">
                             <option value="true">true</option>
                             <option value="false" selected>false</option>
                         </select>
 
-                        <label for="use_music_audio_id">触屏版显示歌曲ID:</label>
-                        <input id="use_music_audio_id" type="text" value="1582971365183456177" />
+                        <label for="continue_play">启用触屏版歌曲封面及歌词，启用继续播放(可能导致兼容性问题):</label>
+                        <select id="continue_play">
+                            <option value="true">true</option>
+                            <option value="false" selected>false</option>
+                        </select>
 
-                        <label for="use_music_id">触屏版显示歌曲分段ID:</label>
-                        <input id="use_music_id" type="text" value="355454500" />
+                        <div style="display: flex; gap: 15px; align-items: flex-end; width: 100%;">
+
+                            <div style="flex: 1; display: flex; flex-direction: column;">
+                                <label for="use_music_audio_id" style="margin-bottom: 6px; display: block;">触屏版默认封面选择(触屏版歌曲封面设为true，才能选择):</label>
+                                <select id="use_music_audio_id" style="width: 100%;">
+                                    <option value="436490277987655" data-img="https://y.gtimg.cn/music/photo_new/T001R500x500M000000XFSu32aHi5w_7.jpg" selected>星河雀影</option>
+                                    <option value="2284848025338642973" data-img="https://y.gtimg.cn/music/photo_new/T002R500x500M000003MUXTN0hp00B_1.jpg">鲸落</option>
+                                    <option value="3032977774822294038" data-img="https://y.gtimg.cn/music/photo_new/T002R500x500M000000P52RF0ePrMh_1.jpg">仲夏涟漪</option>
+                                    <option value="3573885250148762567" data-img="https://y.gtimg.cn/music/photo_new/T002R500x500M000001XSQmy0sbGRe_1.jpg">星辰妙漫</option>
+                                    <option value="2821554561643067278" data-img="https://y.gtimg.cn/music/photo_new/T002R500x500M000003mtKhW0DFTMt_3.jpg">所念皆星河</option>
+                                    <option value="1949968393125757902" data-img="https://y.gtimg.cn/music/photo_new/T002R500x500M000003zlK2H16UvnY_2.jpg">柳岸泊舟</option>
+                                    <option value="1963040443250771008" data-img="https://y.gtimg.cn/music/photo_new/T002R500x500M000004HWTo41EPK3L_2.jpg">花冠少女</option>
+                                    <option value="703059981413384476" data-img="https://y.gtimg.cn/music/photo_new/T002R500x500M000002OGzkK12zb2D_1.jpg">月夜</option>
+                                    <option value="2182123779048604035" data-img="https://y.gtimg.cn/music/photo_new/T002R500x500M000001wIZl83iCjqo_1.jpg">橘子海</option>
+                                    <option value="1299407089048748519" data-img="https://y.gtimg.cn/music/photo_new/T001R500x500M000002knSQ01Ts1vS_0.jpg">拾音者</option>
+                                    <option value="2234266363446166675" data-img="https://y.gtimg.cn/music/photo_new/T002R500x500M000003TkJYk3nWUoB_2.jpg">唱片</option>
+                                    <option value="224322594261696542" data-img="https://y.gtimg.cn/music/photo_new/T002R500x500M000003k0x5s4Ale28_1.jpg">音符</option>
+
+                                </select>
+                            </div>
+
+                            <img id="cover_preview" src="" style="width: 64px; height: 64px; border-radius: 6px; object-fit: cover; border: 1px solid #ddd; display: none;" alt="预览" />
+                        </div>
+
+                        <label for="use_music_id" style="display: none">触屏版显示歌曲分段ID:</label>
+                        <input id="use_music_id" type="text" value="355454500" style="display: none"/>
 
                         <label for="active_cmd">允许唤醒的命令:</label>
                         <input id="active_cmd" type="text"

--- a/xiaomusic/static/default/setting.js
+++ b/xiaomusic/static/default/setting.js
@@ -204,6 +204,14 @@ $(function () {
     if (typeof toggleMultiResultAction === "function") {
       toggleMultiResultAction();
     }
+    if (typeof toggleCoverSelect === "function") {
+      toggleCoverSelect();
+    }
+    var $audioIdSel = $("#use_music_audio_id");
+    if (!$audioIdSel.val()) {
+      $audioIdSel.prop("selectedIndex", 0);
+    }
+    $audioIdSel.trigger("change");
   });
 
     $("#update-devices").on("click", function () {
@@ -653,4 +661,49 @@ $(function () {
       $("#multi_result_action_row").hide();
     }
   };
+
+  // 联动启用封面和封面选择
+  window.toggleCoverSelect = function () {
+    var isContinuePlay = $("#continue_play").val() === "true";
+    var $coverSelect = $("#use_music_audio_id");
+    var $coverLabel = $('label[for="use_music_audio_id"]');
+    var $coverPreview = $("#cover_preview");
+    if (isContinuePlay) {
+      $coverSelect.prop("disabled", false);
+      $coverLabel.css("color", "");
+      $coverSelect.css("color", "");
+
+      // 恢复正常状态
+      $coverPreview.css("opacity", "1");
+      $coverSelect.trigger("change");
+    } else {
+      $coverSelect.prop("disabled", true);
+      $coverLabel.css("color", "#999");
+      $coverSelect.css("color", "transparent");
+
+      // 变成默认占位图
+      $coverPreview.attr("src", "https://y.gtimg.cn/music/photo_new/T001R500x500M000000s13WK28L1rN.jpg");
+      $coverPreview.css("display", "block");
+      $coverPreview.css("opacity", "0.4");
+    }
+  };
+
+  $("#continue_play").on("change", window.toggleCoverSelect);
+
+  // 封面下拉框的图片切换逻辑
+  $("#use_music_audio_id").on("change", function() {
+    // 只有在 continue_play 为 true（开启状态）时，才允许切换图片
+    if ($("#continue_play").val() === "true") {
+      var imgSrc = $(this).find("option:selected").attr("data-img");
+      var $preview = $("#cover_preview");
+      if (imgSrc) {
+        $preview.attr("src", imgSrc).css("display", "block");
+      } else {
+        $preview.css("display", "none");
+      }
+    }
+  });
+
+  $("#use_music_audio_id").trigger("change");
+
 });

--- a/xiaomusic/utils/file_utils.py
+++ b/xiaomusic/utils/file_utils.py
@@ -260,7 +260,9 @@ def is_cache_valid(path: str) -> int:
     return 0
 
 
-def clean_old_caches(cache_dir: str, max_size_mb: int) -> None:
+def clean_old_caches(
+    cache_dir: str, max_size_mb: int, cache_song_name: str = "cache_songs"
+) -> None:
     """
     LRU 清理逻辑：当缓存目录总大小超过设定阈值（MB）时，删除最旧的文件。
     """
@@ -268,7 +270,7 @@ def clean_old_caches(cache_dir: str, max_size_mb: int) -> None:
         return
 
     max_size_bytes = max_size_mb * 1024 * 1024
-    songs_dir = os.path.join(cache_dir, "songs")
+    songs_dir = os.path.join(cache_dir, cache_song_name)
     if not os.path.exists(songs_dir):
         return
 

--- a/xiaomusic/utils/music_utils.py
+++ b/xiaomusic/utils/music_utils.py
@@ -817,7 +817,9 @@ def get_real_audio_format(file_path: str) -> str:
         return "mp3"
 
 
-def build_cache_file_path(datab64: str, name: str, cache_dir: str) -> str:
+def build_cache_file_path(
+    datab64: str, name: str, cache_dir: str, cache_song_name: str = "cache_songs"
+) -> str:
     """
     根据核心字段生成唯一缓存路径，彻底免疫一切前端和插件附加的动态干扰字段。
     """
@@ -843,4 +845,4 @@ def build_cache_file_path(datab64: str, name: str, cache_dir: str) -> str:
 
     safe_name = re.sub(r"[^\w\-_.\s()（）\[\]【】]", "_", name)
     filename = f"{short_hash}_{safe_name}.mp3"
-    return os.path.join(cache_dir, "songs", filename)
+    return os.path.join(cache_dir, cache_song_name, filename)

--- a/xiaomusic/xiaomusic.py
+++ b/xiaomusic/xiaomusic.py
@@ -175,7 +175,9 @@ class XiaoMusic:
         if not os.path.exists(self.config.download_path):
             os.makedirs(self.config.download_path)
 
-        songs_cache_dir = os.path.join(self.config.cache_dir, "songs")
+        songs_cache_dir = os.path.join(
+            self.config.cache_dir, self.config.cache_song_name
+        )
         if getattr(self.config, "cache_max_size_mb", 0) > 0 and not os.path.exists(
             songs_cache_dir
         ):


### PR DESCRIPTION
1. 触屏增加封面选择。
2. 修改默认开启触屏封面，给初次使用者一个好的感官。（默认封面太。。。但，在minaservice.py里面还有祖传id）
3. 修改缓存歌曲目录为cache_songs。之前的songs太大众了。
4. 新增“退出”，“关掉音乐”等口令，避免初次使用者对着会隔几分钟播放音乐而茫然
5. 新增默认口令“搜索歌曲”，“搜索歌手”，“搜索歌单”，好记一点