### PR TITLE
fix: add trailing separator to path containment checks (CWE-22)

### DIFF
--- a/xiaomusic/api/routers/file.py
+++ b/xiaomusic/api/routers/file.py
@@ -965,14 +965,14 @@ async def music_file(request: Request, file_path: str, key: str = "", code: str 
         else:
             temp_base = os.path.abspath(config.temp_path)
         absolute_file_path = os.path.normpath(os.path.join(temp_base, temp_file_name))
-        if not absolute_file_path.startswith(temp_base):
+        if not absolute_file_path.startswith(temp_base + os.sep):
             raise HTTPException(status_code=404, detail="File not found")
         if not os.path.exists(absolute_file_path):
             raise HTTPException(status_code=404, detail="File not found")
     else:
         absolute_path = os.path.abspath(config.music_path)
         absolute_file_path = os.path.normpath(os.path.join(absolute_path, file_path))
-        if not absolute_file_path.startswith(absolute_path):
+        if not absolute_file_path.startswith(absolute_path + os.sep):
             raise HTTPException(status_code=404, detail="File not found")
         if not os.path.exists(absolute_file_path):
             raise HTTPException(status_code=404, detail="File not found")
@@ -1019,7 +1019,7 @@ async def get_picture(request: Request, file_path: str, key: str = "", code: str
 
     absolute_path = os.path.abspath(config.picture_cache_path)
     absolute_file_path = os.path.normpath(os.path.join(absolute_path, file_path))
-    if not absolute_file_path.startswith(absolute_path):
+    if not absolute_file_path.startswith(absolute_path + os.sep):
         raise HTTPException(status_code=404, detail="File not found")
     if not os.path.exists(absolute_file_path):
         raise HTTPException(status_code=404, detail="File not found")


### PR DESCRIPTION
The startswith checks in music_file() and get_picture() lacked a trailing os.sep, allowing sibling-prefix directory traversal.

For example, if music_path="/data/music", a request to /music/../music_secret/file.txt resolves to /data/music_secret/file.txt which passes startswith("/data/music") since "music_secret" starts with "music". Adding os.sep ensures only paths strictly inside the intended directory pass validation.

Affected endpoints:
- GET /music/{file_path:path} (line 968, 975)
- GET /picture/{file_path:path} (line 1022)

#890 