### PR TITLE
Security: Permissive CORS policy exposes authenticated API to any origin

### DIFF
--- a/xiaomusic/api/app.py
+++ b/xiaomusic/api/app.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.gzip import GZipMiddleware
 
 from xiaomusic import __version__
@@ -54,15 +53,6 @@ app = FastAPI(
     docs_url=None,
     redoc_url=None,
     openapi_url=None,
-)
-
-# 添加 CORS 中间件
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],  # 允许访问的源
-    allow_credentials=False,  # 支持 cookie
-    allow_methods=["*"],  # 允许使用的请求方法
-    allow_headers=["*"],  # 允许携带的 Headers
 )
 
 # 添加 GZip 中间件


### PR DESCRIPTION
## Summary

Security: Permissive CORS policy exposes authenticated API to any origin

## Problem

**Severity**: `Medium` | **File**: `xiaomusic/api/app.py:L42`

The FastAPI application allows requests from all origins with all methods and headers. Even though credentials are disabled, any malicious website can still make cross-origin API calls if it can supply an Authorization header or interact with unauthenticated endpoints. This broad policy increases the impact of leaked credentials and makes browser-based attacks against the local control API easier.

## Solution

Restrict allow_origins to trusted UI origins only, such as the configured host/port. Avoid allow_methods=['*'] and allow_headers=['*'] unless required. If the API is intended only for same-origin access, remove CORS entirely.

## Changes

- `xiaomusic/api/app.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.8.0*